### PR TITLE
Replaced .addMagicProperty call with call to .magic  to enable Alpine V3 compatibility

### DIFF
--- a/src/AlpineRayMagicMethod.ts
+++ b/src/AlpineRayMagicMethod.ts
@@ -86,7 +86,7 @@ const AlpineRayMagicMethod = {
         checkForAxios(window);
         checkForAlpine(window);
 
-        window.Alpine.addMagicProperty('ray', () => rayInstance);
+        window.Alpine.magic('ray', () => rayInstance);
     },
 };
 

--- a/tests/AlpineRayMagicMethod.test.ts
+++ b/tests/AlpineRayMagicMethod.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
         },
         Alpine: {
             version: '5.0.0',
-            addMagicProperty(name: string, callback: CallableFunction) {
+            magic(name: string, callback: CallableFunction) {
                 testState.alpineMagicProperties.push({ name, callback });
             },
             onComponentInitialized(callback) {

--- a/tests/SpruceProxy.test.ts
+++ b/tests/SpruceProxy.test.ts
@@ -73,7 +73,7 @@ beforeEach(() => {
         },
         Alpine: {
             version: '5.0.0',
-            addMagicProperty(name: string, callback: CallableFunction) {
+            magic(name: string, callback: CallableFunction) {
                 testState.alpineMagicProperties.push({ name, callback });
             },
             onComponentInitialized(callback) {

--- a/tests/lib/initializeLibrary.test.ts
+++ b/tests/lib/initializeLibrary.test.ts
@@ -58,7 +58,7 @@ beforeEach(() => {
         },
         Alpine: {
             version: '5.0.0',
-            addMagicProperty(name: string, callback: CallableFunction) {
+            magic(name: string, callback: CallableFunction) {
                 testState.alpineMagicProperties.push({ name, callback });
             },
             onComponentInitialized(callback) {


### PR DESCRIPTION
Hi Patrick, 

Thank you for creating alpinejs-ray.
It seems to be the missing alpinejs debugger I've been hoping for - or as close as I've found.

I'm in the process of upgrading my laravel projects to Alpine v3 from Alpine v2.
With the V3 rewrite the .addMagicProperty registration function was replaced with a call to .magic

As a result i get the following errors in my Browser Console and alpine stops working if I add the alpinejs-ray plugin

```
Uncaught TypeError: e.Alpine.addMagicProperty is not a function
Uncaught TypeError: Cannot read property 'parentElement' of undefined
```

I have NO idea what I'm doing, this plugin is *way* above my comfort level,  but I've updated the call in AlpineRayMagicMethod.ts and now my frontend is able to send messages to Ray via the $ray() magic method.

I've also updated the tests - again I have NO idea what I'm doing - to rename the mocks/stubs and the test now pass. Not sure If they should pass but they do.

I hope this helps someone if they come accross the same errors in the future